### PR TITLE
Fix #14 - Add ability to choose Gradle version

### DIFF
--- a/src/main/groovy/nebula/test/IntegrationSpec.groovy
+++ b/src/main/groovy/nebula/test/IntegrationSpec.groovy
@@ -38,6 +38,7 @@ abstract class IntegrationSpec extends Specification {
     private ExecutionResult result
 
     boolean useToolingApi = true
+    String gradleVersion
     LogLevel logLevel = LogLevel.INFO
 
     String moduleName
@@ -88,7 +89,7 @@ abstract class IntegrationSpec extends Specification {
         arguments += '--stacktrace'
         arguments.addAll(args)
 
-        GradleRunner runner = useToolingApi?GradleRunnerFactory.createTooling():GradleRunnerFactory.createLauncher()
+        GradleRunner runner = useToolingApi?GradleRunnerFactory.createTooling(gradleVersion):GradleRunnerFactory.createLauncher()
         runner.handle(projectDir, arguments)
     }
 

--- a/src/main/groovy/nebula/test/functional/GradleRunnerFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/GradleRunnerFactory.groovy
@@ -8,9 +8,8 @@ import nebula.test.functional.internal.toolingapi.ToolingApiGradleHandleFactory;
 
 public class GradleRunnerFactory {
 
-    // TODO Easier way to define which implementation to use
-    public static GradleRunner createTooling() {
-        GradleHandleFactory toolingApiHandleFactory = new ToolingApiGradleHandleFactory();
+    public static GradleRunner createTooling(String version) {
+        GradleHandleFactory toolingApiHandleFactory = new ToolingApiGradleHandleFactory(version);
 
         return create(toolingApiHandleFactory);
     }

--- a/src/main/groovy/nebula/test/functional/internal/DefaultGradleRunner.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/DefaultGradleRunner.groovy
@@ -19,9 +19,6 @@ package nebula.test.functional.internal;
 import nebula.test.functional.ExecutionResult;
 import nebula.test.functional.GradleRunner;
 
-import java.io.File;
-import java.util.List;
-
 public class DefaultGradleRunner implements GradleRunner {
 
     private final GradleHandleFactory handleFactory;
@@ -30,12 +27,12 @@ public class DefaultGradleRunner implements GradleRunner {
         this.handleFactory = handleFactory;
     }
 
-    public ExecutionResult run(File directory, List<String> arguments) {
-        return handle(directory, arguments).run();
+    public ExecutionResult run(File projectDir, List<String> arguments) {
+        return handle(projectDir, arguments).run();
     }
 
-    public GradleHandle handle(File directory, List<String> arguments) {
-        return handleFactory.start(directory, arguments);
+    public GradleHandle handle(File projectDir, List<String> arguments) {
+        return handleFactory.start(projectDir, arguments);
     }
 
 }

--- a/src/main/groovy/nebula/test/functional/internal/classpath/ClasspathInjectingGradleHandleFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/classpath/ClasspathInjectingGradleHandleFactory.groovy
@@ -18,8 +18,8 @@ public class ClasspathInjectingGradleHandleFactory implements GradleHandleFactor
         this.delegateFactory = delegateFactory;
     }
 
-    public GradleHandle start(File directory, List<String> arguments) {
-        File testKitDir = new File(directory, ".gradle-test-kit");
+    public GradleHandle start(File projectDir, List<String> arguments) {
+        File testKitDir = new File(projectDir, ".gradle-test-kit");
         if (!testKitDir.exists()) {
             GFileUtils.mkdirs(testKitDir);
         }
@@ -31,6 +31,6 @@ public class ClasspathInjectingGradleHandleFactory implements GradleHandleFactor
         ammendedArguments.add("--init-script");
         ammendedArguments.add(initScript.getAbsolutePath());
         ammendedArguments.addAll(arguments);
-        return delegateFactory.start(directory, ammendedArguments);
+        return delegateFactory.start(projectDir, ammendedArguments);
     }
 }

--- a/src/test/groovy/nebula/test/SpecifiedGradleVersionIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/test/SpecifiedGradleVersionIntegrationSpec.groovy
@@ -1,0 +1,28 @@
+package nebula.test
+
+import org.gradle.api.logging.LogLevel
+import spock.lang.Unroll
+
+class SpecifiedGradleVersionIntegrationSpec extends IntegrationSpec {
+
+    @Unroll("should use Gradle #requestedGradleVersion when requested")
+    def "should allow to run functional tests with different Gradle versions"() {
+        given:
+            writeHelloWorld('nebula.test.hello')
+            buildFile << '''
+                apply plugin: 'java'
+            '''.stripIndent()
+        and:
+            logLevel = LogLevel.DEBUG
+        and:
+            gradleVersion = requestedGradleVersion
+        when:
+            def result = runTasksSuccessfully('build')
+        then:
+//            //TODO: How to get output before being connected to the daemon?with "Tooling API is using target Gradle version: 1.XX."?
+//            result.getStandardOutput().contains("Tooling API is using target Gradle version: $requestedGradleVersion")
+            result.getStandardOutput().contains("gradle/$requestedGradleVersion/taskArtifacts")
+        where:
+            requestedGradleVersion << ['1.12', '1.6']
+    }
+}


### PR DESCRIPTION
The same as #23, but for the branch `gradle-1.12`.

I implemented an ability to select which Gradle version will be used (in tooling API mode only) for testing the build. It allows to make a regression tests with different plugin version (currently due to #13 only in 1.x or 2.x).

I like the idea with configuration closure used by @johnrengelman in his fork of gradle-test-kit, but I think it is not needed when IntegrationSpec is used (and not GradleRunnerFactory directly).

What do you think about that?
