### PR TITLE
Add specification that delegates to the project under test

### DIFF
--- a/src/main/groovy/nebula/test/ProjectDelegateSpec.groovy
+++ b/src/main/groovy/nebula/test/ProjectDelegateSpec.groovy
@@ -1,0 +1,14 @@
+package nebula.test
+
+import org.gradle.api.internal.project.ProjectInternal
+
+/**
+ * A {@link ProjectSpec} that delegates to the project under test.
+ */
+public class ProjectDelegateSpec extends ProjectSpec {
+    @Delegate ProjectInternal delegate
+
+    def setup() {
+        delegate = project
+    }
+}

--- a/src/main/groovy/nebula/test/ProjectSpec.groovy
+++ b/src/main/groovy/nebula/test/ProjectSpec.groovy
@@ -21,13 +21,13 @@ public abstract class ProjectSpec extends Specification {
     static final String CLEAN_PROJECT_DIR_SYS_PROP = 'cleanProjectDir'
     @TempDirectory File projectDir
 
-    @Rule TestName name = new TestName()
+    @Rule TestName testName = new TestName()
     String canonicalName
     Project project
     MultiProjectHelper helper
 
     def setup() {
-        canonicalName = name.getMethodName().replaceAll(' ', '-')
+        canonicalName = testName.getMethodName().replaceAll(' ', '-')
         project = ProjectBuilder.builder().withName(canonicalName).withProjectDir(projectDir).build()
         helper = new MultiProjectHelper(project)
     }

--- a/src/test/groovy/nebula/test/ConcreteProjectDelegateSpec.groovy
+++ b/src/test/groovy/nebula/test/ConcreteProjectDelegateSpec.groovy
@@ -1,0 +1,27 @@
+package nebula.test
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+class ConcreteProjectDelegateSpec extends ProjectDelegateSpec {
+    def 'has Project'() {
+        expect:
+        project != null
+        delegate != null
+        name == canonicalName
+    }
+
+    def 'can evaluate'() {
+        setup:
+        def signal = new AtomicBoolean(false)
+        afterEvaluate {
+            signal.getAndSet(true)
+        }
+        when:
+        evaluate()
+
+        then:
+        noExceptionThrown()
+        signal.get()
+    }
+
+}


### PR DESCRIPTION
Simplifies writing project tests, and makes test fixtures look more like build files.