### PR TITLE
Ability to debug plugin execution in fork mode

### DIFF
--- a/src/main/groovy/nebula/test/IntegrationSpec.groovy
+++ b/src/main/groovy/nebula/test/IntegrationSpec.groovy
@@ -16,6 +16,8 @@
 package nebula.test
 
 import com.energizedwork.spock.extensions.TempDirectory
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
 import nebula.test.functional.ExecutionResult
 import nebula.test.functional.GradleRunner
 import nebula.test.functional.GradleRunnerFactory
@@ -29,6 +31,7 @@ import spock.lang.Specification
  * @author Justin Ryan
  * @author Marcin Erdmann
  */
+@CompileStatic
 abstract class IntegrationSpec extends Specification {
     private static final String DEFAULT_REMOTE_DEBUG_JVM_ARGUMENTS = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
 
@@ -129,6 +132,7 @@ abstract class IntegrationSpec extends Specification {
         file
     }
 
+    @CompileStatic(TypeCheckingMode.SKIP)
     protected File createFile(String path, File baseDir = projectDir) {
         File file = file(path, baseDir)
         if (!file.exists()) {
@@ -249,6 +253,7 @@ abstract class IntegrationSpec extends Specification {
         result
     }
 
+    @CompileStatic(TypeCheckingMode.SKIP)
     protected ExecutionResult runTasksWithFailure(String... tasks) {
         ExecutionResult result = runTasks(tasks)
         assert result.failure
@@ -267,5 +272,13 @@ abstract class IntegrationSpec extends Specification {
 
     protected File addSubproject(String subprojectName, String subBuildGradleText) {
         helper.addSubproject(subprojectName, subBuildGradleText)
+    }
+
+    File getProjectDir() {
+        return projectDir
+    }
+
+    File getSettingsFile() {
+        return settingsFile
     }
 }

--- a/src/main/groovy/nebula/test/IntegrationSpec.groovy
+++ b/src/main/groovy/nebula/test/IntegrationSpec.groovy
@@ -32,22 +32,21 @@ import spock.lang.Specification
 abstract class IntegrationSpec extends Specification {
     private static final String DEFAULT_REMOTE_DEBUG_JVM_ARGUMENTS = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
 
-    @TempDirectory(clean=false) File projectDir
+    @TempDirectory(clean=false) protected File projectDir
 
     // Holds State of last run
     private ExecutionResult result
 
-    boolean useToolingApi = true
-    String gradleVersion
-    LogLevel logLevel = LogLevel.INFO
+    protected String gradleVersion
+    protected LogLevel logLevel = LogLevel.INFO
 
-    String moduleName
-    File settingsFile
-    File buildFile
-    boolean fork = false
-    boolean remoteDebug = false
-    List<String> jvmArguments = []
-    MultiProjectIntegrationHelper helper
+    protected String moduleName
+    protected File settingsFile
+    protected File buildFile
+    protected boolean fork = false
+    protected boolean remoteDebug = false
+    protected List<String> jvmArguments = []
+    protected MultiProjectIntegrationHelper helper
 
     private String findModuleName() {
         projectDir.getName().replaceAll(/_\d+/, '')
@@ -110,12 +109,12 @@ abstract class IntegrationSpec extends Specification {
      * Override to alter its value
      * @return
      */
-    LogLevel getLogLevel() {
+    protected LogLevel getLogLevel() {
         return logLevel
     }
 
     /* Setup */
-    File directory(String path, File baseDir = projectDir) {
+    protected File directory(String path, File baseDir = projectDir) {
         new File(baseDir, path).with {
             mkdirs()
             it
@@ -130,7 +129,7 @@ abstract class IntegrationSpec extends Specification {
         file
     }
 
-    File createFile(String path, File baseDir = projectDir) {
+    protected File createFile(String path, File baseDir = projectDir) {
         File file = file(path, baseDir)
         if (!file.exists()) {
             assert file.parentFile.mkdirs() || file.parentFile.exists()
@@ -139,7 +138,7 @@ abstract class IntegrationSpec extends Specification {
         file
     }
 
-    def writeHelloWorld(String packageDotted, File baseDir = projectDir) {
+    protected void writeHelloWorld(String packageDotted, File baseDir = projectDir) {
         def path = 'src/main/java/' + packageDotted.replace('.', '/') + '/HelloWorld.java'
         def javaFile = createFile(path, baseDir)
         javaFile << """package ${packageDotted};
@@ -157,7 +156,7 @@ abstract class IntegrationSpec extends Specification {
      * @param failTest true if you want the test to fail, false if the test should pass
      * @param baseDir the directory to begin creation from, defaults to projectDir
      */
-    def writeUnitTest(boolean failTest, File baseDir = projectDir) {
+    protected void writeUnitTest(boolean failTest, File baseDir = projectDir) {
         writeTest('src/test/java/', 'nebula', failTest, baseDir)
     }
 
@@ -169,7 +168,7 @@ abstract class IntegrationSpec extends Specification {
      * @param failTest true if you want the test to fail, false if the test should pass
      * @param baseDir the directory to begin creation from, defaults to projectDir
      */
-    def writeTest(String srcDir, String packageDotted, boolean failTest, File baseDir = projectDir) {
+    protected void writeTest(String srcDir, String packageDotted, boolean failTest, File baseDir = projectDir) {
         def path = srcDir + packageDotted.replace('.', '/') + '/HelloWorldTest.java'
         def javaFile = createFile(path, baseDir)
         javaFile << """package ${packageDotted};
@@ -190,13 +189,13 @@ abstract class IntegrationSpec extends Specification {
      * @param fileName to be used for the file, sans extension.  The .properties extension will be added to the name.
      * @param baseDir the directory to begin creation from, defaults to projectDir
      */
-    def writeResource(String srcDir, String fileName, File baseDir = projectDir) {
+    protected void writeResource(String srcDir, String fileName, File baseDir = projectDir) {
         def path = "$srcDir/${fileName}.properties"
         def resourceFile = createFile(path, baseDir)
         resourceFile.text = "firstProperty=foo.bar"
     }
 
-    void copyResources(String srcDir, String destination) {
+    protected void copyResources(String srcDir, String destination) {
         ClassLoader classLoader = getClass().getClassLoader();
         URL resource = classLoader.getResource(srcDir);
         if (resource == null) {
@@ -212,32 +211,32 @@ abstract class IntegrationSpec extends Specification {
         }
     }
 
-    String applyPlugin(Class pluginClass) {
+    protected String applyPlugin(Class pluginClass) {
         "apply plugin: $pluginClass.name"
     }
 
     /* Checks */
-    boolean fileExists(String path) {
+    protected boolean fileExists(String path) {
         new File(projectDir, path).exists()
     }
 
     @Deprecated
-    boolean wasExecuted(String taskPath) {
+    protected boolean wasExecuted(String taskPath) {
         result.wasExecuted(taskPath)
     }
 
     @Deprecated
-    boolean wasUpToDate(String taskPath) {
+    protected boolean wasUpToDate(String taskPath) {
         result.wasUpToDate(taskPath)
     }
 
     @Deprecated
-    String getStandardError() {
+    protected String getStandardError() {
         result.standardError
     }
 
     @Deprecated
-    String getStandardOutput() {
+    protected String getStandardOutput() {
         result.standardOutput
     }
 
@@ -262,11 +261,11 @@ abstract class IntegrationSpec extends Specification {
         return result
     }
 
-    File addSubproject(String subprojectName) {
+    protected File addSubproject(String subprojectName) {
         helper.addSubproject(subprojectName)
     }
 
-    File addSubproject(String subprojectName, String subBuildGradleText) {
+    protected File addSubproject(String subprojectName, String subBuildGradleText) {
         helper.addSubproject(subprojectName, subBuildGradleText)
     }
 }

--- a/src/main/groovy/nebula/test/PluginProjectSpec.groovy
+++ b/src/main/groovy/nebula/test/PluginProjectSpec.groovy
@@ -15,12 +15,14 @@
  */
 package nebula.test
 
+import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 
 /**
  * Create some basic tests that all plugins should pass
  */
+@CompileStatic
 abstract class PluginProjectSpec extends ProjectSpec {
     abstract String getPluginName()
 

--- a/src/main/groovy/nebula/test/functional/GradleRunner.groovy
+++ b/src/main/groovy/nebula/test/functional/GradleRunner.groovy
@@ -18,9 +18,6 @@ package nebula.test.functional;
 
 import nebula.test.functional.internal.GradleHandle;
 
-import java.io.File;
-import java.util.List;
-
 public interface GradleRunner {
 
     /**
@@ -29,7 +26,9 @@ public interface GradleRunner {
      * @param args
      * @return results from execution
      */
-    ExecutionResult run(File directory, List<String> args);
+    ExecutionResult run(File directory, List<String> args)
+
+    ExecutionResult run(File directory, List<String> args, List<String> jvmArgs)
 
     /**
      * Handle on instance of Gradle that can be run.
@@ -37,6 +36,7 @@ public interface GradleRunner {
      * @param args
      * @return handle
      */
-    GradleHandle handle(File directory, List<String> args);
+    GradleHandle handle(File directory, List<String> args)
 
+    GradleHandle handle(File directory, List<String> args, List<String> jvmArgs)
 }

--- a/src/main/groovy/nebula/test/functional/GradleRunnerFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/GradleRunnerFactory.groovy
@@ -1,11 +1,13 @@
 package nebula.test.functional
 
+import groovy.transform.CompileStatic
 import nebula.test.functional.internal.DefaultGradleRunner
 import nebula.test.functional.internal.GradleHandleFactory
 import nebula.test.functional.internal.classpath.ClasspathInjectingGradleHandleFactory
 import nebula.test.functional.internal.toolingapi.ToolingApiGradleHandleFactory
 
-public class GradleRunnerFactory {
+@CompileStatic
+class GradleRunnerFactory {
     public static GradleRunner createTooling(boolean fork = false, String version = null) {
         GradleHandleFactory toolingApiHandleFactory = new ToolingApiGradleHandleFactory(fork, version);
         return create(toolingApiHandleFactory);

--- a/src/main/groovy/nebula/test/functional/internal/DefaultExecutionResult.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/DefaultExecutionResult.groovy
@@ -16,10 +16,12 @@
 
 package nebula.test.functional.internal
 
+import groovy.transform.CompileStatic
 import nebula.test.functional.ExecutionResult
 import org.gradle.api.GradleException
 
-public abstract class DefaultExecutionResult implements ExecutionResult {
+@CompileStatic
+abstract class DefaultExecutionResult implements ExecutionResult {
     private final Boolean success
     private final String standardOutput
     private final String standardError
@@ -51,9 +53,9 @@ public abstract class DefaultExecutionResult implements ExecutionResult {
 
     @Override
     boolean wasExecuted(String taskPath) {
-        executedTasks.any {
+        executedTasks.any { ExecutedTask task ->
             taskPath = normalizeTaskPath(taskPath)
-            def match = it.path == taskPath
+            def match = task.path == taskPath
             return match
         }
     }
@@ -74,9 +76,9 @@ public abstract class DefaultExecutionResult implements ExecutionResult {
 
     private ExecutedTask getExecutedTaskByPath(String taskPath) {
         taskPath = normalizeTaskPath(taskPath)
-        def task = executedTasks.find { it.path == taskPath }
+        def task = executedTasks.find { ExecutedTask task -> task.path == taskPath }
         if (task == null) {
-            throw RuntimeException("Task with path $taskPath was not found")
+            throw new RuntimeException("Task with path $taskPath was not found")
         }
         task
     }

--- a/src/main/groovy/nebula/test/functional/internal/DefaultGradleRunner.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/DefaultGradleRunner.groovy
@@ -16,10 +16,12 @@
 
 package nebula.test.functional.internal
 
+import groovy.transform.CompileStatic
 import nebula.test.functional.ExecutionResult
 import nebula.test.functional.GradleRunner
 
-public class DefaultGradleRunner implements GradleRunner {
+@CompileStatic
+class DefaultGradleRunner implements GradleRunner {
 
     private final GradleHandleFactory handleFactory;
 

--- a/src/main/groovy/nebula/test/functional/internal/DefaultGradleRunner.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/DefaultGradleRunner.groovy
@@ -27,12 +27,13 @@ public class DefaultGradleRunner implements GradleRunner {
         this.handleFactory = handleFactory;
     }
 
-    public ExecutionResult run(File projectDir, List<String> arguments) {
-        return handle(projectDir, arguments).run();
+    @Override
+    public ExecutionResult run(File projectDir, List<String> arguments, List<String> jvmArguments = []) {
+        return handle(projectDir, arguments, jvmArguments).run();
     }
 
-    public GradleHandle handle(File projectDir, List<String> arguments) {
-        return handleFactory.start(projectDir, arguments);
+    @Override
+    public GradleHandle handle(File projectDir, List<String> arguments, List<String> jvmArguments = []) {
+        return handleFactory.start(projectDir, arguments, jvmArguments);
     }
-
 }

--- a/src/main/groovy/nebula/test/functional/internal/GradleHandleFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/GradleHandleFactory.groovy
@@ -4,4 +4,5 @@ public interface GradleHandleFactory {
 
     GradleHandle start(File dir, List<String> arguments);
 
+    GradleHandle start(File dir, List<String> arguments, List<String> jvmArguments);
 }

--- a/src/main/groovy/nebula/test/functional/internal/classpath/ClasspathAddingInitScriptBuilder.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/classpath/ClasspathAddingInitScriptBuilder.groovy
@@ -1,5 +1,6 @@
 package nebula.test.functional.internal.classpath
 
+import groovy.transform.CompileStatic
 import org.gradle.api.Transformer;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
@@ -8,7 +9,8 @@ import org.gradle.internal.classloader.ClasspathUtil;
 import org.gradle.util.CollectionUtils
 import org.gradle.util.TextUtil;
 
-public class ClasspathAddingInitScriptBuilder {
+@CompileStatic
+class ClasspathAddingInitScriptBuilder {
 
     public void build(File initScriptFile, final ClassLoader classLoader) {
         build(initScriptFile, getClasspathAsFiles(classLoader));

--- a/src/main/groovy/nebula/test/functional/internal/classpath/ClasspathInjectingGradleHandleFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/classpath/ClasspathInjectingGradleHandleFactory.groovy
@@ -1,10 +1,12 @@
 package nebula.test.functional.internal.classpath
 
+import groovy.transform.CompileStatic
 import nebula.test.functional.internal.GradleHandle
 import nebula.test.functional.internal.GradleHandleFactory
 import org.gradle.util.GFileUtils
 
-public class ClasspathInjectingGradleHandleFactory implements GradleHandleFactory {
+@CompileStatic
+class ClasspathInjectingGradleHandleFactory implements GradleHandleFactory {
 
     private final ClassLoader classLoader;
     private final GradleHandleFactory delegateFactory;

--- a/src/main/groovy/nebula/test/functional/internal/classpath/ClasspathInjectingGradleHandleFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/classpath/ClasspathInjectingGradleHandleFactory.groovy
@@ -14,7 +14,8 @@ public class ClasspathInjectingGradleHandleFactory implements GradleHandleFactor
         this.delegateFactory = delegateFactory;
     }
 
-    public GradleHandle start(File projectDir, List<String> arguments) {
+    @Override
+    public GradleHandle start(File projectDir, List<String> arguments, List<String> jvmArguments = []) {
         File testKitDir = new File(projectDir, ".gradle-test-kit");
         if (!testKitDir.exists()) {
             GFileUtils.mkdirs(testKitDir);
@@ -27,6 +28,6 @@ public class ClasspathInjectingGradleHandleFactory implements GradleHandleFactor
         ammendedArguments.add("--init-script");
         ammendedArguments.add(initScript.getAbsolutePath());
         ammendedArguments.addAll(arguments);
-        return delegateFactory.start(projectDir, ammendedArguments);
+        return delegateFactory.start(projectDir, ammendedArguments, jvmArguments);
     }
 }

--- a/src/main/groovy/nebula/test/functional/internal/toolingapi/BuildLauncherBackedGradleHandle.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/toolingapi/BuildLauncherBackedGradleHandle.groovy
@@ -16,6 +16,7 @@
 
 package nebula.test.functional.internal.toolingapi
 
+import groovy.transform.CompileStatic
 import nebula.test.functional.ExecutionResult
 import nebula.test.functional.internal.GradleHandle
 import nebula.test.functional.internal.GradleHandleBuildListener
@@ -24,7 +25,8 @@ import org.gradle.tooling.BuildLauncher
 import org.gradle.tooling.ProgressEvent
 import org.gradle.tooling.ProgressListener
 
-public class BuildLauncherBackedGradleHandle implements GradleHandle {
+@CompileStatic
+class BuildLauncherBackedGradleHandle implements GradleHandle {
 
     final private ByteArrayOutputStream standardOutput = new ByteArrayOutputStream();
     final private ByteArrayOutputStream standardError = new ByteArrayOutputStream();

--- a/src/main/groovy/nebula/test/functional/internal/toolingapi/BuildLauncherBackedGradleHandle.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/toolingapi/BuildLauncherBackedGradleHandle.groovy
@@ -71,6 +71,7 @@ public class BuildLauncherBackedGradleHandle implements GradleHandle {
         return standardError.toString();
     }
 
+    @Override
     public ExecutionResult run() {
         Throwable failure = null;
         try {

--- a/src/main/groovy/nebula/test/functional/internal/toolingapi/MinimalExecutedTask.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/toolingapi/MinimalExecutedTask.groovy
@@ -15,11 +15,13 @@
  */
 package nebula.test.functional.internal.toolingapi
 
+import groovy.transform.CompileStatic
 import nebula.test.functional.internal.ExecutedTask
 
 /**
  * @author Marcin Erdmann
  */
+@CompileStatic
 class MinimalExecutedTask implements ExecutedTask {
 
     String path

--- a/src/main/groovy/nebula/test/functional/internal/toolingapi/ToolingApiGradleHandleFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/toolingapi/ToolingApiGradleHandleFactory.groovy
@@ -20,7 +20,8 @@ public class ToolingApiGradleHandleFactory implements GradleHandleFactory {
         this.version = version
     }
 
-    public GradleHandle start(File projectDir, List<String> arguments) {
+    @Override
+    public GradleHandle start(File projectDir, List<String> arguments, List<String> jvmArguments = []) {
         GradleConnector connector = createGradleConnector(projectDir)
 
         boolean forkedProcess = isForkedProcess()
@@ -29,7 +30,7 @@ public class ToolingApiGradleHandleFactory implements GradleHandleFactory {
         connector.embedded(!forkedProcess)
 
         ProjectConnection connection = connector.connect();
-        BuildLauncher launcher = createBuildLauncher(connection, arguments)
+        BuildLauncher launcher = createBuildLauncher(connection, arguments, jvmArguments)
         createGradleHandle(connection, launcher, forkedProcess)
     }
 
@@ -70,11 +71,10 @@ public class ToolingApiGradleHandleFactory implements GradleHandleFactory {
         Boolean.parseBoolean(System.getProperty(FORK_SYS_PROP, Boolean.FALSE.toString()))
     }
 
-    private BuildLauncher createBuildLauncher(ProjectConnection connection, List<String> arguments) {
+    private BuildLauncher createBuildLauncher(ProjectConnection connection, List<String> arguments, List<String> jvmArguments) {
         BuildLauncher launcher = connection.newBuild();
-        String[] argumentArray = new String[arguments.size()];
-        arguments.toArray(argumentArray);
-        launcher.withArguments(argumentArray);
+        launcher.withArguments(arguments as String[]);
+        launcher.setJvmArguments(jvmArguments as String[])
         launcher
     }
 

--- a/src/main/groovy/nebula/test/functional/internal/toolingapi/ToolingApiGradleHandleFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/toolingapi/ToolingApiGradleHandleFactory.groovy
@@ -11,7 +11,8 @@ import org.gradle.tooling.ProjectConnection
 import org.gradle.wrapper.WrapperExecutor
 
 public class ToolingApiGradleHandleFactory implements GradleHandleFactory {
-    static final String FORK_SYS_PROP = 'nebula.test.functional.fork'
+    public static final String FORK_SYS_PROP = 'nebula.test.functional.fork'
+
     private final boolean fork
     private final String version
 

--- a/src/main/groovy/nebula/test/functional/internal/toolingapi/ToolingApiGradleHandleFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/toolingapi/ToolingApiGradleHandleFactory.groovy
@@ -1,5 +1,7 @@
 package nebula.test.functional.internal.toolingapi
 
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
 import nebula.test.functional.internal.GradleHandle
 import nebula.test.functional.internal.GradleHandleBuildListener
 import nebula.test.functional.internal.GradleHandleFactory
@@ -10,6 +12,7 @@ import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
 import org.gradle.wrapper.WrapperExecutor
 
+@CompileStatic
 public class ToolingApiGradleHandleFactory implements GradleHandleFactory {
     public static final String FORK_SYS_PROP = 'nebula.test.functional.fork'
 
@@ -22,6 +25,7 @@ public class ToolingApiGradleHandleFactory implements GradleHandleFactory {
     }
 
     @Override
+    @CompileStatic(TypeCheckingMode.SKIP)
     public GradleHandle start(File projectDir, List<String> arguments, List<String> jvmArguments = []) {
         GradleConnector connector = createGradleConnector(projectDir)
 

--- a/src/main/groovy/nebula/test/functional/internal/toolingapi/ToolingExecutionResult.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/toolingapi/ToolingExecutionResult.groovy
@@ -1,14 +1,15 @@
 package nebula.test.functional.internal.toolingapi
 
+import groovy.transform.CompileStatic
 import nebula.test.functional.internal.DefaultExecutionResult
 
 /**
  * Hold additional response data, that is only available
  */
+@CompileStatic
 class ToolingExecutionResult extends DefaultExecutionResult {
 
     ToolingExecutionResult(Boolean success, String standardOutput, String standardError,  List<MinimalExecutedTask> executedTasks, Throwable failure) {
         super(success, standardOutput, standardError, executedTasks, failure)
     }
-
 }

--- a/src/main/groovy/nebula/test/multiproject/MultiProjectHelper.groovy
+++ b/src/main/groovy/nebula/test/multiproject/MultiProjectHelper.groovy
@@ -1,8 +1,10 @@
 package nebula.test.multiproject
 
+import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 
+@CompileStatic
 class MultiProjectHelper {
     Project parent
 

--- a/src/main/groovy/nebula/test/multiproject/MultiProjectInfo.groovy
+++ b/src/main/groovy/nebula/test/multiproject/MultiProjectInfo.groovy
@@ -1,7 +1,9 @@
 package nebula.test.multiproject
 
+import groovy.transform.CompileStatic
 import org.gradle.api.Project
 
+@CompileStatic
 class MultiProjectInfo {
     String name
     Project parent

--- a/src/main/groovy/nebula/test/multiproject/MultiProjectIntegrationHelper.groovy
+++ b/src/main/groovy/nebula/test/multiproject/MultiProjectIntegrationHelper.groovy
@@ -1,7 +1,9 @@
 package nebula.test.multiproject
 
+import groovy.transform.CompileStatic
 import nebula.test.IntegrationSpec
 
+@CompileStatic
 class MultiProjectIntegrationHelper {
     static String lineEnd = System.getProperty('line.separator')
 

--- a/src/main/groovy/nebula/test/multiproject/MultiProjectIntegrationInfo.groovy
+++ b/src/main/groovy/nebula/test/multiproject/MultiProjectIntegrationInfo.groovy
@@ -1,5 +1,8 @@
 package nebula.test.multiproject
 
+import groovy.transform.CompileStatic
+
+@CompileStatic
 class MultiProjectIntegrationInfo {
     String name
     File directory

--- a/src/test/groovy/nebula/test/JvmArgumentsIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/test/JvmArgumentsIntegrationSpec.groovy
@@ -1,0 +1,21 @@
+package nebula.test
+
+class JvmArgumentsIntegrationSpec extends IntegrationSpec {
+
+    private static final String TEST_JVM_ARGUMENT = "-XX:-PrintClassHistogram"
+
+    def "should start Gradle with custom JVM argument in fork mode"() {
+        given:
+            writeHelloWorld('nebula.test.hello')
+            buildFile << '''
+                apply plugin: 'java'
+            '''.stripIndent()
+        and:
+            fork = true
+            jvmArguments = [TEST_JVM_ARGUMENT]
+        when:
+            def result = runTasksSuccessfully('compileJava')
+        then:
+            result.standardOutput.contains(TEST_JVM_ARGUMENT)
+    }
+}


### PR DESCRIPTION
Ability to debug plugin execution in test mode. As shown in #29 and #32 fork mode is required in some cases.

Setting `remoteDebug` to `true` passes default debug parameters to Gradle JVM. Custom arguments can be passed with `jvmArguments`.

The functional changes are only in the first commit (see [diff](https://github.com/szpak/nebula-test/commit/beaf1eaf2ce1175906d59e5cb3077fdf83dd2ea7)). Others changes helped me to find places where the code should be adjusted to my code modifications (`@CompileStatic`). If you don't like those additional changes (or would prefer to browse it separately) I can remove them from the PR and create another one which depends on that code).

The [idea](http://forums.gradle.org/gradle/topics/unable-to-catch-stdout-stderr-when-using-tooling-api-i-gradle-2-x#reply_15357743) by @erdi.