### PR TITLE
Adding Init Script support, PreExecutionActions, and fixing bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,29 @@ MultiProjectIntegrationHelper can create sub-projects using our IntegrationSpec.
         }
     }
 
+Pre Build Hooks
+---------------
+
+### PreExecutionAction
+
+PreExecutionActions allows for actions to happen before gradle is executed.
+
+### Usage for PreExecutionAction:
+
+    addPreExecute(new PreExecutionAction() {
+        @Override
+        void execute(File projectDir, List<String> arguments, List<String> jvmArguments) {
+            initScript.text = '''
+            gradle.projectsLoaded {
+                gradle.rootProject.tasks.create('foo')
+            }
+            '''.stripIndent()
+        }
+    })
+
+The PreExecutionAction lets you automatically add steps to the test that get executed just before run is called. This is particularly useful when tests change a value that is needed during the execution allowing the action to be defined in a setup, and delayed until the execution.
+
+
 Caveat
 ------
 * This would have been in nebula-core, but via POMs you can't get dependencies just for tests.

--- a/src/main/groovy/nebula/test/functional/GradleRunner.groovy
+++ b/src/main/groovy/nebula/test/functional/GradleRunner.groovy
@@ -65,6 +65,8 @@ public interface GradleRunner {
 
     ExecutionResult run(File directory, List<String> args, List<String> jvmArgs)
 
+    ExecutionResult run(File directory, List<String> args, List<String> jvmArgs, List<PreExecutionAction> preExecutionActions)
+
     /**
      * Handle on instance of Gradle that can be run.
      * @param directory
@@ -74,4 +76,6 @@ public interface GradleRunner {
     GradleHandle handle(File directory, List<String> args)
 
     GradleHandle handle(File directory, List<String> args, List<String> jvmArgs)
+
+    GradleHandle handle(File directory, List<String> args, List<String> jvmArgs, List<PreExecutionAction> preExecutionActions)
 }

--- a/src/main/groovy/nebula/test/functional/PreExecutionAction.java
+++ b/src/main/groovy/nebula/test/functional/PreExecutionAction.java
@@ -1,0 +1,12 @@
+package nebula.test.functional;
+
+import java.io.File;
+import java.util.List;
+
+
+/**
+ * Executes actions before gradle is called.
+ */
+public interface PreExecutionAction {
+  void execute(File projectDir, List<String> arguments, List<String> jvmArguments);
+}

--- a/src/main/groovy/nebula/test/functional/internal/DefaultGradleRunner.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/DefaultGradleRunner.groovy
@@ -19,6 +19,7 @@ package nebula.test.functional.internal
 import groovy.transform.CompileStatic
 import nebula.test.functional.ExecutionResult
 import nebula.test.functional.GradleRunner
+import nebula.test.functional.PreExecutionAction
 
 @CompileStatic
 class DefaultGradleRunner implements GradleRunner {
@@ -29,12 +30,13 @@ class DefaultGradleRunner implements GradleRunner {
     }
 
     @Override
-    public ExecutionResult run(File projectDir, List<String> arguments, List<String> jvmArguments = []) {
-        return handle(projectDir, arguments, jvmArguments).run();
+    public ExecutionResult run(File projectDir, List<String> arguments, List<String> jvmArguments = [], List<PreExecutionAction> preExecutionActions = []) {
+        return handle(projectDir, arguments, jvmArguments, preExecutionActions).run();
     }
 
     @Override
-    public GradleHandle handle(File projectDir, List<String> arguments, List<String> jvmArguments = []) {
+    public GradleHandle handle(File projectDir, List<String> arguments, List<String> jvmArguments = [], List<PreExecutionAction> preExecutionActions = []) {
+        preExecutionActions?.each { it.execute(projectDir, arguments, jvmArguments) }
         return handleFactory.start(projectDir, arguments, jvmArguments);
     }
 }

--- a/src/test/groovy/nebula/test/ChangingTestDirSpec.groovy
+++ b/src/test/groovy/nebula/test/ChangingTestDirSpec.groovy
@@ -1,0 +1,15 @@
+package nebula.test
+
+
+import com.energizedwork.spock.extensions.TempDirectory
+
+class ChangingTestDirSpec extends IntegrationSpec {
+
+  @TempDirectory(clean = false, baseDir = 'test/build1') File projectDir
+
+  def 'can change name of project dir'() {
+    expect:
+    projectDir.absolutePath.contains('test/build1')
+  }
+
+}

--- a/src/test/groovy/nebula/test/functional/internal/DefaultGradleRunnerSpec.groovy
+++ b/src/test/groovy/nebula/test/functional/internal/DefaultGradleRunnerSpec.groovy
@@ -1,0 +1,44 @@
+package nebula.test.functional.internal
+
+
+import nebula.test.functional.PreExecutionAction
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class DefaultGradleRunnerSpec extends Specification {
+
+  @Rule TemporaryFolder temporaryFolder
+
+  def 'will execute actions before run is called'() {
+    setup:
+    def projectDir = temporaryFolder.newFolder()
+    def handleFactory = Mock(GradleHandleFactory)
+    def runner = new DefaultGradleRunner(handleFactory)
+
+    when:
+    runner.handle(projectDir, ['arg'], ['jvm'], [new WriteFileAction(projectDir)])
+
+    then:
+    1 * handleFactory.start(projectDir, ['arg'], ['jvm'])
+  }
+
+  static class WriteFileAction implements PreExecutionAction {
+    File expectedDir
+
+    WriteFileAction(File expectedDir) {
+      this.expectedDir = expectedDir
+    }
+
+    @Override
+    void execute(File projectDir, List<String> arguments, List<String> jvmArguments) {
+      assert expectedDir.absolutePath == projectDir.absolutePath
+
+      assert arguments.size() == 1
+      assert arguments.first() == 'arg'
+
+      assert jvmArguments.size() == 1
+      assert jvmArguments.first() == 'jvm'
+    }
+  }
+}


### PR DESCRIPTION
The bug prevents people from being able to specify the project dir
themselves using the annotation.

PreExecutionActions allow for people to cleanly extend nebula-test by adding
actions to to happen before builds. This can help when files need to be
written all the time, but the test sets up the data while running (can't
happen in the setup method)

And finally giving people the ability to add custom init scripts.