### PR TITLE
Implement memory safe mode for testing with multiple Gradle versions

### DIFF
--- a/src/main/groovy/nebula/test/functional/GradleRunnerFactory.groovy
+++ b/src/main/groovy/nebula/test/functional/GradleRunnerFactory.groovy
@@ -9,8 +9,9 @@ import nebula.test.functional.internal.toolingapi.ToolingApiGradleHandleFactory
 
 @CompileStatic
 class GradleRunnerFactory {
-    public static GradleRunner createTooling(boolean fork = false, String version = null, Predicate<URL> classpathFilter = null) {
-        GradleHandleFactory toolingApiHandleFactory = new ToolingApiGradleHandleFactory(fork, version);
+    public static GradleRunner createTooling(boolean fork = false, String version = null, Integer daemonMaxIdleTimeInSeconds = null,
+                                             Predicate<URL> classpathFilter = null) {
+        GradleHandleFactory toolingApiHandleFactory = new ToolingApiGradleHandleFactory(fork, version, daemonMaxIdleTimeInSeconds);
         return create(toolingApiHandleFactory, classpathFilter ?: GradleRunner.CLASSPATH_DEFAULT);
     }
 


### PR DESCRIPTION
When activated Gradle daemon is shutdown automatically after 15 seconds
being idle. This is very useful for testing on shared CI nodes or
compatibility testing with multiple Gradle versions.

Trick suggested by @kelemen on [Gradle forum](https://discuss.gradle.org/t/stopping-gradle-daemon-via-tooling-api/16004/3?u=marcin).

I tried to build nebula-test after my change with 3.0-milestone-1 and it also seems to work fine.
