### PR TITLE
Add convinent verify method noSource to ExecutionResult

### DIFF
--- a/src/main/groovy/nebula/test/functional/ExecutionResult.groovy
+++ b/src/main/groovy/nebula/test/functional/ExecutionResult.groovy
@@ -27,7 +27,9 @@ public interface ExecutionResult {
 
     boolean wasUpToDate(String taskPath);
 
-    boolean wasSkipped(String taskPath)
+    boolean wasSkipped(String taskPath);
+
+    boolean noSource(String taskPath);
 
     Throwable getFailure();
 

--- a/src/main/groovy/nebula/test/functional/internal/DefaultExecutionResult.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/DefaultExecutionResult.groovy
@@ -70,6 +70,11 @@ abstract class DefaultExecutionResult implements ExecutionResult {
         getExecutedTaskByPath(taskPath).skipped
     }
 
+    @Override
+    boolean noSource(String taskPath) {
+        getExecutedTaskByPath(taskPath).noSource
+    }
+
     String normalizeTaskPath(String taskPath) {
         taskPath.startsWith(':') ? taskPath : ":$taskPath"
     }

--- a/src/main/groovy/nebula/test/functional/internal/ExecutedTask.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/ExecutedTask.groovy
@@ -4,4 +4,5 @@ interface ExecutedTask {
     String getPath()
     boolean isUpToDate()
     boolean isSkipped()
+    boolean isNoSource()
 }

--- a/src/main/groovy/nebula/test/functional/internal/toolingapi/BuildLauncherBackedGradleHandle.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/toolingapi/BuildLauncherBackedGradleHandle.groovy
@@ -94,7 +94,8 @@ class BuildLauncherBackedGradleHandle implements GradleHandle {
             // Scan stdout for task's up to date
             boolean upToDate = isTaskUpToDate(stdout, taskName)
             boolean skipped = isTaskSkipped(stdout, taskName)
-            tasks.add( new MinimalExecutedTask(taskName, upToDate, skipped) );
+            boolean noSource = isTaskNoSource(stdout, taskName)
+            tasks.add( new MinimalExecutedTask(taskName, upToDate, skipped, noSource) );
         }
         boolean success = failure == null
         return new ToolingExecutionResult(success, stdout, getStandardError(), tasks, failure);
@@ -106,6 +107,10 @@ class BuildLauncherBackedGradleHandle implements GradleHandle {
 
     private isTaskSkipped(String stdout, String taskName) {
         containsOutput(stdout, taskName, 'SKIPPED')
+    }
+
+    private isTaskNoSource(String stdout, String taskName) {
+        containsOutput(stdout, taskName, 'NO-SOURCE')
     }
 
     private boolean containsOutput(String stdout, String taskName, String stateIdentifier) {

--- a/src/main/groovy/nebula/test/functional/internal/toolingapi/MinimalExecutedTask.groovy
+++ b/src/main/groovy/nebula/test/functional/internal/toolingapi/MinimalExecutedTask.groovy
@@ -27,11 +27,13 @@ class MinimalExecutedTask implements ExecutedTask {
     String path
     boolean upToDate
     boolean skipped
+    boolean noSource
 
-    MinimalExecutedTask(String path, boolean upToDate, boolean skipped) {
+    MinimalExecutedTask(String path, boolean upToDate, boolean skipped, boolean noSource) {
         this.path = path
         this.upToDate = upToDate
         this.skipped = skipped
+        this.noSource = noSource
     }
 
     String toString() {

--- a/src/test/groovy/nebula/test/functional/SomePlugin.groovy
+++ b/src/test/groovy/nebula/test/functional/SomePlugin.groovy
@@ -33,5 +33,13 @@ class SomePlugin implements Plugin<Project> {
                 System.err.println 'Printed (stderr)'
             }
         }
+
+        project.task("sourceMe", type: SomeTask) {
+            if(project.hasProperty('source')) {
+                input = project.projectDir
+            }
+
+            doLast { project.logger.quiet 'You gave me source!' }
+        }
     }
 }

--- a/src/test/groovy/nebula/test/functional/SomeTask.groovy
+++ b/src/test/groovy/nebula/test/functional/SomeTask.groovy
@@ -1,0 +1,12 @@
+package nebula.test.functional
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.SkipWhenEmpty
+
+class SomeTask extends DefaultTask {
+
+    @SkipWhenEmpty
+    @InputDirectory
+    File input
+}

--- a/src/test/groovy/nebula/test/functional/TestSpec.groovy
+++ b/src/test/groovy/nebula/test/functional/TestSpec.groovy
@@ -37,27 +37,33 @@ class TestSpec extends Specification {
         """
 
         when:
-        ExecutionResult result = runner.run(tmp.root, ["echo", "doIt", "-PupToDate=false", "-Pskip=false"])
+        ExecutionResult result = runner.run(tmp.root, ["echo", "doIt", "sourceMe", "-PupToDate=false", "-Pskip=false", "-Psource=true"])
         !result.wasExecuted(":hush")
         result.wasExecuted(":echo")
         !result.wasUpToDate(":echo")
         result.wasExecuted(":doIt")
         !result.wasSkipped(":doIt")
+        result.wasExecuted(":sourceMe")
+        !result.noSource(":sourceMe")
 
         then:
         result.standardOutput.contains("I ran!")
         result.standardOutput.contains("Did it!")
+        result.standardOutput.contains("You gave me source!")
 
         when:
-        result = runner.run(tmp.root, ["echo", "doIt", "-PupToDate=true", "-Pskip=true"])
+        result = runner.run(tmp.root, ["echo", "doIt", "sourceMe", "-PupToDate=true", "-Pskip=true"])
 
         then:
         !result.standardOutput.contains("I ran!")
         !result.standardOutput.contains("Did it!")
+        !result.standardOutput.contains("You gave me source!")
         result.wasExecuted(":echo")
         result.wasUpToDate(":echo")
         result.wasExecuted(":doIt")
         result.wasSkipped(":doIt")
+        result.wasExecuted(":sourceMe")
+        result.noSource(":sourceMe")
 
         where:
         type         | forked


### PR DESCRIPTION
To test custom tasks classes with the `SkipWhenEmpty` anotation on
`InputDirectory` or `InputFiles` task inputs I added a new check method
`noSource` to the `ExecutionResult` interface.

I added a small test task class and case in the functional `TestSpec`
see:
`SomeTask`, `SomePlugin` and `TestSpec`

I hope the method names are ok.