### PR TITLE
Do Not Reference Subproject Variable in Root

### DIFF
--- a/src/main/groovy/nebula/test/dependencies/GradleDependencyGenerator.groovy
+++ b/src/main/groovy/nebula/test/dependencies/GradleDependencyGenerator.groovy
@@ -38,18 +38,6 @@ class GradleDependencyGenerator {
                         }
                     }
                 }
-                publications {
-                    maven(MavenPublication) {
-                        artifactId artifactName
-
-                        from components.java
-                    }
-                    ivy(IvyPublication) {
-                        module artifactName
-
-                        from components.java
-                    }
-                }
             }
         }
     '''.stripIndent()
@@ -159,7 +147,13 @@ class GradleDependencyGenerator {
             }
             publishing {
                 publications {
+                    maven(MavenPublication) {
+                        artifactId artifactName
+                        from components.java
+                    }
                     ivy(IvyPublication) {
+                        module artifactName
+                        from components.java
                         descriptor.status = '${node.status}'
                     }
                 }


### PR DESCRIPTION
Prior to this change, nebula-test would generate a subprojects block in the root project that referenced a variable defined in the subproject. This worked in Gradle 4.8-20180426000029+0000 and earlier, but started failing with error 'Could not get unknown property ...' as of 4.8-20180426235958+0000.