### PR TITLE
fail tests if mutable project state warning is present

### DIFF
--- a/src/main/groovy/nebula/test/BaseIntegrationSpec.groovy
+++ b/src/main/groovy/nebula/test/BaseIntegrationSpec.groovy
@@ -99,6 +99,20 @@ abstract class BaseIntegrationSpec extends Specification {
         }
     }
 
+    protected static void checkForMutableProjectState(String output) {
+        def mutableProjectStateWarnings = output.readLines().findAll {
+            it.contains("was resolved without accessing the project in a safe manner") ||
+                    it.contains("This may happen when a configuration is resolved from a thread not managed by Gradle or from a different project")
+
+        }
+
+        if (!System.getProperty("ignoreMutableProjectStateWarnings") && !mutableProjectStateWarnings.isEmpty()) {
+            throw new IllegalArgumentException("Mutable Project State warnings were found (Set the ignoreMutableProjectStateWarnings system property during the test to ignore):\n" + mutableProjectStateWarnings.collect {
+                " - $it"
+            }.join("\n"))
+        }
+    }
+
     protected void writeHelloWorld(String packageDotted, File baseDir = getProjectDir()) {
         def path = 'src/main/java/' + packageDotted.replace('.', '/') + '/HelloWorld.java'
         def javaFile = createFile(path, baseDir)

--- a/src/main/groovy/nebula/test/IntegrationSpec.groovy
+++ b/src/main/groovy/nebula/test/IntegrationSpec.groovy
@@ -166,6 +166,7 @@ abstract class IntegrationSpec extends BaseIntegrationSpec {
 
     protected ExecutionResult checkForDeprecations(ExecutionResult result) {
         checkForDeprecations(result.standardOutput)
+        checkForMutableProjectState(result.standardOutput)
         return result
     }
 


### PR DESCRIPTION
This is to start failing integration tests if mutable project state warnings are found in gradle build output. 

https://github.com/gradle/gradle/blob/250961e81b7d83da020caa43bdeb4cd9c40a150c/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java#L535