### PR TITLE
When this library is used with Gradle 6 and higher it published Gradle metadata allowing us to specify more details about dummy libraries

### DIFF
--- a/src/main/groovy/nebula/test/dependencies/DependencyGraphNode.groovy
+++ b/src/main/groovy/nebula/test/dependencies/DependencyGraphNode.groovy
@@ -16,12 +16,14 @@
 package nebula.test.dependencies
 
 import groovy.transform.Immutable
+import org.gradle.api.JavaVersion
 
 @Immutable(knownImmutableClasses = [Coordinate])
 class DependencyGraphNode {
     @Delegate Coordinate coordinate
     List<Coordinate> dependencies = []
     String status = "integration"
+    JavaVersion targetCompatibility = JavaVersion.VERSION_1_8
 
     @Override
     String toString() {

--- a/src/main/groovy/nebula/test/dependencies/GradleDependencyGenerator.groovy
+++ b/src/main/groovy/nebula/test/dependencies/GradleDependencyGenerator.groovy
@@ -193,6 +193,9 @@ class GradleDependencyGenerator {
             ext {
                 artifactName = '${node.artifact}'
             }
+            
+            targetCompatibility = ${node.targetCompatibility}
+            
             publishing {
                 publications {
                     maven(MavenPublication) {

--- a/src/test/groovy/nebula/test/dependencies/GradleDependencyGeneratorSpec.groovy
+++ b/src/test/groovy/nebula/test/dependencies/GradleDependencyGeneratorSpec.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.test.dependencies
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.invocation.Gradle
 import spock.lang.Specification
 
@@ -219,6 +220,21 @@ class GradleDependencyGeneratorSpec extends Specification {
         def repo = new File(directory)
         new File(repo, 'ivyrepo/test/ivy/foo-final/1.0.0/foo-final-1.0.0-ivy.xml').text.contains 'status="release"'
         new File(repo, 'ivyrepo/test/ivy/foo-candidate/1.0.0/foo-candidate-1.0.0-ivy.xml').text.contains 'status="candidate"'
+    }
+
+    def 'allow different target compatibility'() {
+        def directory = 'build/testdependencies/ivyxml'
+        def graph = [
+                new DependencyGraphNode(coordinate: new Coordinate(group: 'test.ivy', artifact: 'foo-final', version: '1.0.0'), status: "release", targetCompatibility: JavaVersion.VERSION_1_7),
+        ]
+        def generator = new GradleDependencyGenerator(new DependencyGraph(nodes: graph), directory)
+
+        when:
+        generator.generateTestIvyRepo()
+
+        then:
+        def repo = new File(directory)
+        new File(repo, 'ivyrepo/test/ivy/foo-final/1.0.0/foo-final-1.0.0.module').text.contains '"org.gradle.jvm.version": 7'
     }
 
     def 'check ivy xml'() {


### PR DESCRIPTION
If we like this. I would add details to docs. You need to run your tests with Gradle 6 so target compatibility is actually published in Gradle metadata.