### PR TITLE
NEBULA-3615 add missing subProject extension method for GroovyDsl

### DIFF
--- a/.github/workflows/nebula.yml
+++ b/.github/workflows/nebula.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v4
   buildmultijdk:
     if: (!startsWith(github.ref, 'refs/tags/v'))
     needs: validation

--- a/src/main/groovy/nebula/test/dsl/GroovyDsl.groovy
+++ b/src/main/groovy/nebula/test/dsl/GroovyDsl.groovy
@@ -21,6 +21,10 @@ class GroovyDsl {
         self.plugins().with(config)
     }
 
+    static void subProject(TestProjectBuilder self, String name, @DelegatesTo(ProjectBuilder) Closure config) {
+        self.subProject(name).with(config)
+    }
+
     static void plugins(ProjectBuilder self, @DelegatesTo(PluginsBuilder) Closure config) {
         self.plugins().with(config)
     }

--- a/src/test/groovy/nebula/test/dsl/GroovyDslTest.groovy
+++ b/src/test/groovy/nebula/test/dsl/GroovyDslTest.groovy
@@ -44,4 +44,38 @@ public class Main {
         assertThat(result).task(":compileJava").hasOutcome(TaskOutcome.SUCCESS)
         assertThat(result).task(":build").hasOutcome(TaskOutcome.SUCCESS)
     }
+
+    @Test
+    void testMultiProject() {
+        final var runner = GroovyTestProjectBuilder.testProject(testProjectDir) {
+            subProject("sub1") {
+                plugins {
+                    java()
+                }
+                src {
+                    main {
+                        java("Main.java") {
+                            // language=java
+                            """
+public class Main {
+    public static void main(String[] args) {
+    }
+}
+"""
+                        }
+                    }
+                }
+            }
+        }
+
+        final var result = runner.run(["build"]) {
+            forwardOutput()
+        }
+
+        assertThat(result)
+                .hasNoDeprecationWarnings()
+                .hasNoMutableStateWarnings()
+        assertThat(result).task(":sub1:compileJava").hasOutcome(TaskOutcome.SUCCESS)
+        assertThat(result).task(":sub1:build").hasOutcome(TaskOutcome.SUCCESS)
+    }
 }


### PR DESCRIPTION
add missing subProject extension method for GroovyDsl

update to latest gradle wrapper validation action because https://github.com/gradle/wrapper-validation-action is deprecated