### PR TITLE
Add abstract class variant of IntegrationTestKitBase

### DIFF
--- a/src/main/groovy/nebula/test/AbstractIntegrationTestKitBase.groovy
+++ b/src/main/groovy/nebula/test/AbstractIntegrationTestKitBase.groovy
@@ -1,0 +1,10 @@
+package nebula.test
+
+import groovy.transform.CompileStatic
+
+/**
+ * Base class for implementing gradle integration tests using the {@code gradle-test-kit} runner.
+ */
+@CompileStatic
+abstract class AbstractIntegrationTestKitBase implements IntegrationTestKitBase {
+}

--- a/src/test/java/nebula/test/IntegrationTestKitTest.java
+++ b/src/test/java/nebula/test/IntegrationTestKitTest.java
@@ -1,0 +1,44 @@
+package nebula.test;
+
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static nebula.test.dsl.TestKitAssertions.assertThat;
+
+public class IntegrationTestKitTest extends AbstractIntegrationTestKitBase {
+
+    @BeforeEach
+    public void init(TestInfo testInfo) {
+        super.initialize(getClass(), testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    public void cleanup() {
+        traitCleanup();
+    }
+
+    @Test
+    public void testIntegrationTestKit() throws IOException {
+        try (var writer = new FileWriter(getBuildFile())) {
+            writer.write("""
+                plugins {
+                    id 'java'
+                }
+            """);
+        }
+
+        var result = runTasks("build");
+
+        assertThat(result)
+                .hasNoDeprecationWarnings()
+                .hasNoMutableStateWarnings();
+        assertThat(result).task(":compileJava").hasOutcome(TaskOutcome.NO_SOURCE);
+        assertThat(result).task(":build").hasOutcome(TaskOutcome.SUCCESS);
+    }
+}


### PR DESCRIPTION
IntegrationTestKitBase is currently defined as a Groovy trait, which makes it difficult to use directly in Java or Kotlin projects. This change introduces an abstract class variant to improve interoperability across JVM languages