### PR TITLE
streamline github actions

### DIFF
--- a/.github/workflows/nebula.yml
+++ b/.github/workflows/nebula.yml
@@ -2,7 +2,7 @@ name: Nebula Build
 on:
   push:
     branches:
-      - '*'
+      - 'main'
     tags:
       - v*.*.*
       - v*.*.*-rc.*


### PR DESCRIPTION
currently, every PR runs the build twice: once as a "push" and once as a "pull request". we only need to build "push" on main branch, not all, since we will build any pull request from a branch