### PR TITLE
don't enable output forwarding by default in basic run method

### DIFF
--- a/src/main/java/nebula/test/dsl/TestProjectRunner.java
+++ b/src/main/java/nebula/test/dsl/TestProjectRunner.java
@@ -28,7 +28,7 @@ public class TestProjectRunner {
      * @return the BuildResult
      */
     public BuildResult run(String... args) {
-        return run(GradleRunner.create().forwardOutput(), Arrays.asList(args));
+        return run(GradleRunner.create(), Arrays.asList(args));
     }
 
     /**


### PR DESCRIPTION
this makes it more consistent with default testkit behavior as well as the other signatures of this method